### PR TITLE
Fix bug when using BCFtools caller

### DIFF
--- a/pathogenprofiler/bam.py
+++ b/pathogenprofiler/bam.py
@@ -34,6 +34,8 @@ class bam:
             self.gatk_gvcf(bed_file=bed_file if not whole_genome else None, whole_genome=whole_genome)
         else:
             self.bcftools_gbcf(prefix=self.prefix,call_method=call_method,min_dp=min_dp,threads=threads,vtype="both",bed_file=bed_file,low_dp_as_missing=True)
+            gbcf_file = self.gvcf_file.replace('.vcf.gz', '.gbcf')
+            run_cmd("bcftools view -Ov -l 1 -o %(gvcf_file)s %(gbcf_file)s" % vars(self))
 
         self.variant_vcf_file = "%s.vcf.gz" % self.prefix
         self.del_bed = bcf(self.gvcf_file).del_pos2bed(bed_file)

--- a/pathogenprofiler/bam.py
+++ b/pathogenprofiler/bam.py
@@ -35,7 +35,7 @@ class bam:
         else:
             self.bcftools_gbcf(prefix=self.prefix,call_method=call_method,min_dp=min_dp,threads=threads,vtype="both",bed_file=bed_file,low_dp_as_missing=True)
             gbcf_file = self.gvcf_file.replace('.vcf.gz', '.gbcf')
-            run_cmd("bcftools view -Ov -l 1 -o %(gvcf_file)s %(gbcf_file)s" % vars(self))
+            run_cmd("bcftools view -Ov -l 1 -o %(gvcf_file)s %(gbcf_file)s" % {**vars(self), 'gbcf_file': gbcf_file})
 
         self.variant_vcf_file = "%s.vcf.gz" % self.prefix
         self.del_bed = bcf(self.gvcf_file).del_pos2bed(bed_file)


### PR DESCRIPTION
The code in [`bam.py`](https://github.com/jodyphelan/pathogen-profiler/blob/master/pathogenprofiler/bam.py#L39) assumes that the file for the next step of analysis is a `.vcf.gz` file, whereas the BCFTools caller creates a `.gbcf` file. This patch adds code so ensure that the BCFtools caller generates a `.vcf.gz` file and the following workflow works.