### PR TITLE
db-dir

### DIFF
--- a/pathogenprofiler/__init__.py
+++ b/pathogenprofiler/__init__.py
@@ -10,4 +10,4 @@ from .barcode import *
 from .cli import *
 from .rules import *
 from .models import *
-__version__ = "4.6.0"
+__version__ = "4.6.1"

--- a/pathogenprofiler/bam.py
+++ b/pathogenprofiler/bam.py
@@ -396,7 +396,10 @@ class Bam:
             self.calculate_bed_depth(bed_file)
         target_qc = []
         for r, data in load_bed(self.bed_file).items():
-            target = data[4]
+            if len(data)==7:
+                target = data[6]
+            else:
+                target = data[4]
             target_depth = [p for p in self.position_depth if p in r]
             region_len = len(target_depth)
             pos_pass_thresh = len([p for p in target_depth if p.depth>=cutoff])

--- a/pathogenprofiler/cli.py
+++ b/pathogenprofiler/cli.py
@@ -71,7 +71,7 @@ def get_resistance_db_from_species_prediction(args: argparse.Namespace,species_p
     logging.debug("Attempting to load db with species prediction")
     number_of_species = len(set([s.species for s in species_prediction.species]))
     if number_of_species==1:
-        return get_db(args.software_name,species_prediction.species[0].species.replace(" ","_")) 
+        return get_db(args.db_dir,species_prediction.species[0].species.replace(" ","_")) 
     else:
         return None
     
@@ -294,7 +294,7 @@ def set_platform_params(args):
     return args
 
 def get_sourmash_hit(args):
-    args.species_conf = get_db(args.software_name,args.species_db)
+    args.species_conf = get_db(args.db_dir,args.species_db)
     if args.read1:
         if args.read2:
             fastq = Fastq(args.read1,args.read2)
@@ -311,6 +311,8 @@ def get_sourmash_hit(args):
         fastq = Fastq(fq_file)
         sourmash_sig = fastq.sourmash_sketch(args.files_prefix)
 
+    # print(args.species_conf)
+    # quit()
     sourmash_sig = sourmash_sig.gather(args.species_conf["sourmash_db"],args.species_conf["sourmash_db_info"],intersect_bp=500000,f_match_threshold=0.1)
     result =  []
 
@@ -346,8 +348,8 @@ def set_species(args: argparse.Namespace) -> SpeciesPrediction:
     >>> species_prediction.species
     [Species(species='Mycobacterium abscessus', prediction_info=None)]
     """
-    check_db_exists(args.software_name,args.resistance_db)
-    conf = get_db(args.software_name,args.resistance_db)
+    check_db_exists(args.db_dir,args.resistance_db)
+    conf = get_db(args.db_dir,args.resistance_db)
     species = Species(
         species=conf["species"]
     )
@@ -375,7 +377,7 @@ def get_sourmash_species_prediction(args: argparse.Namespace) -> SpeciesPredicti
         A SpeciesPrediction object
 
     """
-    conf = get_db(args.software_name,args.species_db)
+    conf = get_db(args.db_dir,args.species_db)
     sourmash_species_prediction = get_sourmash_hit(args)
     species = []
     for obj in sourmash_species_prediction:

--- a/pathogenprofiler/profiler.py
+++ b/pathogenprofiler/profiler.py
@@ -52,7 +52,13 @@ def vcf_profiler(args: argparse.Namespace) -> List[Union[Variant,DrVariant,Gene,
         run_cmd("bcftools index %s" % args.vcf)
     if args.caller == 'freebayes-haplotype':
         args.supplementary_bam = None
-    annotated_variants = vcf_variant_profiler(conf, args.files_prefix, args.vcf, bam_for_phasing=args.supplementary_bam)
+    annotated_variants = vcf_variant_profiler(
+        conf=conf, 
+        prefix=args.files_prefix, 
+        vcf_file=args.vcf, 
+        bam_for_phasing=args.supplementary_bam,
+        snpeff_config=args.snpeff_config if hasattr(args,'snpeff_config') else None
+    )
     return annotated_variants
     
  
@@ -60,13 +66,13 @@ def vcf_profiler(args: argparse.Namespace) -> List[Union[Variant,DrVariant,Gene,
 
 
 
-def vcf_variant_profiler(conf: dict, prefix: str, vcf_file: str, bam_for_phasing: str = None) -> List[Union[Variant,Gene]]:
+def vcf_variant_profiler(conf: dict, prefix: str, vcf_file: str, bam_for_phasing: str = None, snpeff_config: str = None) -> List[Union[Variant,Gene]]:
     vcf_targets_file = "%s.targets_for_profile.vcf.gz" % prefix
     if not vcf_is_indexed(vcf_file):
         run_cmd("bcftools index %s" % vcf_file)
     run_cmd("bcftools view -R %s %s -Oz -o %s" % (conf["bed"],vcf_file,vcf_targets_file))
     vcf_obj = Vcf(vcf_targets_file)
-    vcf_obj = vcf_obj.run_snpeff(conf["snpEff_db"],conf["ref"],conf["gff"],rename_chroms= conf.get("chromosome_conversion",None),bam_for_phasing=bam_for_phasing)
+    vcf_obj = vcf_obj.run_snpeff(conf["snpEff_db"],conf["ref"],conf["gff"],rename_chroms=conf.get("chromosome_conversion",None),bam_for_phasing=bam_for_phasing, snpeff_config=snpeff_config)
     variants = vcf_obj.load_ann(conf['variant_filters'],bed_file=conf["bed"],keep_variant_types = ["ablation","upstream","synonymous","noncoding"])
 
     # compare against database of variants

--- a/pathogenprofiler/vcf.py
+++ b/pathogenprofiler/vcf.py
@@ -30,6 +30,8 @@ def get_stand_support(var: pysam.VariantRecord,alt: str) -> Tuple[int,int]:
     else:
         forward_support = None
         reverse_support = None
+    
+    logging.debug(f"Forward support: {forward_support}, Reverse support: {reverse_support}")
     return forward_support, reverse_support
 
 def get_sv_ad(var):

--- a/pathogenprofiler/vcf.py
+++ b/pathogenprofiler/vcf.py
@@ -10,6 +10,24 @@ import pysam
 from .models import Variant,Consequence, VcfQC, GenomePosition
 from typing import Optional, List, Tuple, Dict
 
+def get_default_snpeff_config():
+    share_dir = os.path.join(sys.base_prefix, 'share')
+    # check folder exists
+    if os.path.isdir(share_dir):
+        snp_eff_dirs = [d for d in os.listdir(share_dir) if d.startswith('snpeff-')]
+        if len(snp_eff_dirs) == 1:
+            snp_eff_dir = snp_eff_dirs[0]
+            return os.path.join(share_dir, snp_eff_dir, 'snpEff.config')
+    
+def get_custom_snpeff_config(software_name: str):
+    # check folder exists
+    share_dir = os.path.join(sys.base_prefix, 'share')
+    software_dir = os.path.join(share_dir, software_name)
+    if os.path.isdir(software_dir):
+        config = os.path.join(software_dir, 'snpEff.config')
+        if os.path.isfile(config):
+            return config
+
 def get_stand_support(var: pysam.VariantRecord,alt: str) -> Tuple[int,int]:
     alt_index = list(var.alts).index(alt)
     forward_support = None
@@ -86,55 +104,18 @@ class Vcf:
         return Vcf(self.newfile)
 
 
-    def set_snpeff_datadir(self):
-        """
-            Look for snpEff database directory and if not found, set it to current working directory.
-            Store the directory found in self.snpeff_data_dir
-        """
-        snpeff_basedir = None
-        for path_el in os.environ.get('PATH','').split(os.pathsep):
-            path_el = path_el.strip('"')
-
-            fpath = os.path.join(path_el, 'snpEff')
-
-            if os.path.isfile(fpath) and os.access(fpath, os.X_OK):
-                snpeff_basedir = path_el.rstrip('/').rstrip('bin')
-                break
-        
-        snpeff_data_dir = None
-        if snpeff_basedir is not None:
-            snpeff_shared_dir = os.path.join(snpeff_basedir, 'share')
-            for path_el in os.listdir(snpeff_shared_dir):
-                if path_el.startswith('snpeff-'):
-                    snpeff_data_dir = os.path.join(snpeff_shared_dir, path_el, 'data')
-                    snpeff_db_dir = os.path.join(snpeff_data_dir, self.db)
-                    if not os.path.isdir(snpeff_data_dir) and os.access(os.path.join(snpeff_shared_dir, path_el), os.W_OK | os.X_OK | os.R_OK):
-                        os.mkdir(snpeff_data_dir)
-                    if (os.path.isdir(snpeff_db_dir) or 
-                        (os.path.isdir(snpeff_data_dir) and os.access(snpeff_data_dir, os.W_OK | os.X_OK | os.R_OK))
-                        ):
-                        self.snpeff_data_dir = snpeff_data_dir
-                        return snpeff_data_dir
-
-        # if we have got here, we need to try an store the snpEff DB in the current working directory
-        snpeff_data_dir = os.getcwd()
-        if os.access(snpeff_data_dir, os.W_OK | os.R_OK):
-            self.snpeff_data_dir = snpeff_data_dir
-            return snpeff_data_dir
-        
-        return None
-
-    def run_snpeff(self,db,ref_file,gff_file,rename_chroms = None, split_indels=True, bam_for_phasing=None):
+    def run_snpeff(self, db: str,ref_file: str,gff_file: str,rename_chroms: dict = None, split_indels: bool=True, bam_for_phasing: str=None, snpeff_config: str=None):
         logging.info("Running snpEff")
         add_arguments_to_self(self,locals())
         self.vcf_csq_file = self.prefix+".csq.vcf.gz"
         self.rename_cmd = f"rename_vcf_chrom.py --source {' '.join(rename_chroms['source'])} --target {' '.join(rename_chroms['target'])} |" if rename_chroms else ""
         self.re_rename_cmd = f"| rename_vcf_chrom.py --source {' '.join(rename_chroms['target'])} --target {' '.join(rename_chroms['source'])}" if rename_chroms else ""
-        if self.set_snpeff_datadir() is None:
-            logging.warning("snpEff database not found and no writeable directory to store database in, analysis might fail", file=sys.stderr)
-            self.snpeff_data_dir_opt = ''
+        
+        if snpeff_config:
+            self.snpeff_config_opt = f'-config {snpeff_config}'
         else:
-            self.snpeff_data_dir_opt = '-dataDir %(snpeff_data_dir)s' % vars(self)
+            self.snpeff_config_opt = f'-config {get_default_snpeff_config()}'
+
         if split_indels:
             with TempFilePrefix() as tmp:
                 self.tmp_file1 = f"{tmp}.1.vcf.gz"
@@ -144,10 +125,10 @@ class Vcf:
                     self.phasing_bam = f"--bam {bam_for_phasing}"
                 else:
                     self.phasing_bam = ""
-                run_cmd("bcftools view -a %(filename)s | bcftools view -c 1 | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - |  combine_vcf_variants.py --ref %(ref_file)s --gff %(gff_file)s %(phasing_bam)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(vcf_csq_file)s" % vars(self))
+                run_cmd("bcftools view -a %(filename)s | bcftools view -c 1 | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - |  combine_vcf_variants.py --ref %(ref_file)s --gff %(gff_file)s %(phasing_bam)s | %(rename_cmd)s snpEff ann %(snpeff_config_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(vcf_csq_file)s" % vars(self))
                 
         else :
-            run_cmd("bcftools view %(filename)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools view -Oz -o %(vcf_csq_file)s" % vars(self))
+            run_cmd("bcftools view %(filename)s | %(rename_cmd)s snpEff ann %(snpeff_config_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools view -Oz -o %(vcf_csq_file)s" % vars(self))
         return Vcf(self.vcf_csq_file,self.prefix)
 
 

--- a/pathogenprofiler/vcf.py
+++ b/pathogenprofiler/vcf.py
@@ -142,11 +142,8 @@ class Vcf:
                     self.phasing_bam = f"--bam {bam_for_phasing}"
                 else:
                     self.phasing_bam = ""
-                run_cmd("bcftools view -c 1 -a %(filename)s | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - |  combine_vcf_variants.py --ref %(ref_file)s --gff %(gff_file)s %(phasing_bam)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(vcf_csq_file)s" % vars(self))
-                # run_cmd("bcftools view -c 1 -a %(filename)s | bcftools view -v snps | combine_vcf_variants.py --ref %(ref_file)s --gff %(gff_file)s %(phasing_bam)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(tmp_file1)s && bcftools index %(tmp_file1)s" % vars(self))
-                # run_cmd("bcftools view -c 1 -a %(filename)s | bcftools view -v indels | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(tmp_file2)s && bcftools index %(tmp_file2)s" % vars(self))
-                # run_cmd("bcftools view -c 1 -a %(filename)s | bcftools view -v other | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(tmp_file3)s && bcftools index %(tmp_file3)s" % vars(self))
-                # run_cmd("bcftools concat -a %(tmp_file1)s %(tmp_file2)s %(tmp_file3)s | bcftools sort -Oz -o %(vcf_csq_file)s" % vars(self))
+                run_cmd("bcftools view -a %(filename)s | bcftools view -c 1 | realign_tandem_deletions.py - %(ref_file)s %(gff_file)s - |  combine_vcf_variants.py --ref %(ref_file)s --gff %(gff_file)s %(phasing_bam)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools sort -Oz -o %(vcf_csq_file)s" % vars(self))
+                
         else :
             run_cmd("bcftools view %(filename)s | %(rename_cmd)s snpEff ann %(snpeff_data_dir_opt)s -noLog -noStats %(db)s - %(re_rename_cmd)s | bcftools view -Oz -o %(vcf_csq_file)s" % vars(self))
         return Vcf(self.vcf_csq_file,self.prefix)


### PR DESCRIPTION
Added a --db-dir argument which will define the location where all the databases will go (for the species assignment and resistance workflows). So this can be run both at the `update_db` and the `profile` step. I've also now made the snpEff databases go there with a custom config file instead or modifying the original snpEff config